### PR TITLE
allow configuration of ClipMode original drawer

### DIFF
--- a/src/MT.MudBlazor.Extensions/Components/Drawer/DrawerOptions.cs
+++ b/src/MT.MudBlazor.Extensions/Components/Drawer/DrawerOptions.cs
@@ -15,4 +15,6 @@ public class DrawerOptions
     public string Width { get; set; }
 
     public string Height { get; set; }
+
+    public DrawerClipMode? ClipMode { get; set; }
 }

--- a/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerInstance.razor
+++ b/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerInstance.razor
@@ -5,7 +5,7 @@
     @* use @bind-Open="@DrawerOpen" to close on click away *@
     @if (DisableBackdropClick)
     {
-        <MudDrawer Open="@DrawerOpen" Anchor="@Anchor" ClipMode="DrawerClipMode.Never" Color="@Color" DisableOverlay="@DisableOverlay" Elevation="@Elevation" Width="@Width" Height="@Height" Variant="DrawerVariant.Temporary">
+        <MudDrawer Open="@DrawerOpen" Anchor="@Anchor" ClipMode="@ClipMode" Color="@Color" DisableOverlay="@DisableOverlay" Elevation="@Elevation" Width="@Width" Height="@Height" Variant="DrawerVariant.Temporary">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">@Title</MudText>
             </MudDrawerHeader>
@@ -16,7 +16,7 @@
     }
     else
     {
-        <MudDrawer @bind-Open="@DrawerOpen" Anchor="@Anchor" ClipMode="DrawerClipMode.Never" Color="@Color" DisableOverlay="@DisableOverlay" Elevation="@Elevation" Width="@Width" Height="@Height" Variant="DrawerVariant.Temporary">
+        <MudDrawer @bind-Open="@DrawerOpen" Anchor="@Anchor" ClipMode="@ClipMode" Color="@Color" DisableOverlay="@DisableOverlay" Elevation="@Elevation" Width="@Width" Height="@Height" Variant="DrawerVariant.Temporary">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">@Title</MudText>
             </MudDrawerHeader>

--- a/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerInstance.razor.cs
+++ b/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerInstance.razor.cs
@@ -51,6 +51,8 @@ public partial class MudDrawerInstance : MudComponentBase, IDisposable
 
     private string Height => Options.Height ?? GlobalDrawerOptions.Height;
 
+    private DrawerClipMode ClipMode => Options.ClipMode ?? GlobalDrawerOptions.ClipMode ?? DrawerClipMode.Never;
+
     public void SetOptions(DrawerOptions options)
     {
         Options = options;

--- a/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerProvider.razor.cs
+++ b/src/MT.MudBlazor.Extensions/Components/Drawer/MudDrawerProvider.razor.cs
@@ -21,8 +21,9 @@ public partial class MudDrawerProvider : IDisposable
 
     [Parameter] [Category(CategoryTypes.Drawer.Appearance)] public string Width { get; set; }
 
-    [Parameter] [Category(CategoryTypes.Drawer.Appearance)] public string Height { get; set; }
-    
+    [Parameter][Category(CategoryTypes.Drawer.Appearance)] public string Height { get; set; }
+    [Parameter][Category(CategoryTypes.Drawer.Appearance)] public DrawerClipMode? ClipMode { get; set; }
+
     private readonly Collection<IDrawerReference> _drawers = new();
     private readonly DrawerOptions _globalDrawerOptions = new();
 
@@ -39,6 +40,7 @@ public partial class MudDrawerProvider : IDisposable
         _globalDrawerOptions.Elevation = Elevation;
         _globalDrawerOptions.Width = Width;
         _globalDrawerOptions.Height = Height;
+        _globalDrawerOptions.ClipMode = ClipMode;
     }
 
     internal void DismissInstance(Guid id, DrawerResult result)


### PR DESCRIPTION
Hello, 

first of all thanks a lot for your Extensions, I was searching for exactly the same thing (ie drawer use like a dialog) in MudBlazor.

One of my requirement was to be able to display the drawer without hiding the AppBar. So I've made this small PR to allow access to this options of the original drawer.

Thanks!